### PR TITLE
Fix user guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A scriptable UI testing tool for Eclipse RCP projects.
 ## Weblinks
 * [official Website](https://eclipse.dev/rcptt/)
 * [Download](https://download.eclipse.org/rcptt/)
-* [User Guide](https://eclipse.dev/rcptt/documentation/userguide/)
+* [User Guide](https://eclipse.dev/rcptt/userguide/)
 * [ECL documentation](https://download.eclipse.org/rcptt/nightly/2.5.5/latest/doc/ecl/)
 * [Forums](http://eclipse.org/forums/eclipse.rcptt)
 * [Continous Integration](https://ci.eclipse.org/rcptt/)


### PR DESCRIPTION
It seems a redesign of the website broke many links.
See also https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5510