### PR TITLE
Use Tycho 4

### DIFF
--- a/modules/nebula/plugins/org.eclipse.rcptt.module.nebula.updates/pom.xml
+++ b/modules/nebula/plugins/org.eclipse.rcptt.module.nebula.updates/pom.xml
@@ -27,7 +27,7 @@
       <groupId>org.eclipse.rcptt</groupId>
       <artifactId>org.eclipse.rcptt.module.nebula-runtime-site</artifactId>
       <version>2.6.0-SNAPSHOT</version>
-      <type>eclipse-update-site</type>
+      <type>eclipse-repository</type>
     </dependency>
   </dependencies>
 

--- a/modules/nebula/runtime-site/pom.xml
+++ b/modules/nebula/runtime-site/pom.xml
@@ -21,6 +21,6 @@
   </parent>
 
   <artifactId>org.eclipse.rcptt.module.nebula-runtime-site</artifactId>
-  <packaging>eclipse-update-site</packaging>
+  <packaging>eclipse-repository</packaging>
 
 </project>

--- a/modules/nebula/site/pom.xml
+++ b/modules/nebula/site/pom.xml
@@ -21,5 +21,5 @@
 	</parent>
 
 	<artifactId>org.eclipse.rcptt.module.nebula-site</artifactId>
-	<packaging>eclipse-update-site</packaging>
+	<packaging>eclipse-repository</packaging>
 </project>

--- a/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.recording.swt.rap/pom.xml
+++ b/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.recording.swt.rap/pom.xml
@@ -33,17 +33,6 @@
     <plugins>
       <plugin>
         <groupId>${tycho-groupid}</groupId>
-        <artifactId>tycho-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.rcptt.tesla</groupId>
-            <artifactId>org.eclipse.rcptt.tesla.swt.fragment.rap</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
            <dependency-resolution>

--- a/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.swt.rap/pom.xml
+++ b/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.swt.rap/pom.xml
@@ -33,17 +33,6 @@
     <plugins>
       <plugin>
         <groupId>${tycho-groupid}</groupId>
-        <artifactId>tycho-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.rcptt.tesla</groupId>
-            <artifactId>org.eclipse.rcptt.tesla.swt.fragment.rap</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
            <dependency-resolution>

--- a/modules/testrail/plugins/org.eclipse.rcptt.module.testrail.updates/pom.xml
+++ b/modules/testrail/plugins/org.eclipse.rcptt.module.testrail.updates/pom.xml
@@ -27,7 +27,7 @@
       <groupId>org.eclipse.rcptt</groupId>
       <artifactId>org.eclipse.rcptt.module.testrail-runtime-site</artifactId>
       <version>2.6.0-SNAPSHOT</version>
-      <type>eclipse-update-site</type>
+      <type>eclipse-repository</type>
     </dependency>
   </dependencies>
 

--- a/modules/testrail/runtime-site/pom.xml
+++ b/modules/testrail/runtime-site/pom.xml
@@ -21,6 +21,6 @@
   </parent>
 
   <artifactId>org.eclipse.rcptt.module.testrail-runtime-site</artifactId>
-  <packaging>eclipse-update-site</packaging>
+  <packaging>eclipse-repository</packaging>
 
 </project>

--- a/modules/testrail/site/pom.xml
+++ b/modules/testrail/site/pom.xml
@@ -21,5 +21,5 @@
 	</parent>
 
 	<artifactId>org.eclipse.rcptt.module.testrail-site</artifactId>
-	<packaging>eclipse-update-site</packaging>
+	<packaging>eclipse-repository</packaging>
 </project>

--- a/modules/zephyr/site/pom.xml
+++ b/modules/zephyr/site/pom.xml
@@ -21,5 +21,5 @@
 	</parent>
 
 	<artifactId>org.eclipse.rcptt.module.zephyr-site</artifactId>
-	<packaging>eclipse-update-site</packaging>
+	<packaging>eclipse-repository</packaging>
 </project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -16,7 +16,7 @@
   <version>2.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <tycho-version>2.7.5</tycho-version>
+    <tycho-version>4.0.11</tycho-version>
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ajdt43repository>http://download.eclipse.org/tools/ajdt/43/update/</ajdt43repository>
@@ -57,7 +57,7 @@
           <version>${tycho-version}</version>
           <dependencies>
             <dependency>
-              <groupId>org.eclipse.tycho.extras</groupId>
+              <groupId>org.eclipse.tycho</groupId>
               <artifactId>tycho-buildtimestamp-jgit</artifactId>
               <version>${tycho-version}</version>
             </dependency>

--- a/runtime/tesla/org.eclipse.rcptt.tesla.recording.swt/pom.xml
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.recording.swt/pom.xml
@@ -31,17 +31,6 @@
     <plugins>
       <plugin>
         <groupId>${tycho-groupid}</groupId>
-        <artifactId>tycho-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.rcptt.tesla</groupId>
-            <artifactId>org.eclipse.rcptt.tesla.swt.fragment</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
            <dependency-resolution>

--- a/runtime/tesla/org.eclipse.rcptt.tesla.swt/pom.xml
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.swt/pom.xml
@@ -31,17 +31,6 @@
     <plugins>
       <plugin>
         <groupId>${tycho-groupid}</groupId>
-        <artifactId>tycho-compiler-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.eclipse.rcptt.tesla</groupId>
-            <artifactId>org.eclipse.rcptt.tesla.swt.fragment</artifactId>
-            <version>2.6.0-SNAPSHOT</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>${tycho-groupid}</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
            <dependency-resolution>


### PR DESCRIPTION
This fixes regression introduced by Maven update in #111

```
[ERROR] Failed to execute goal org.eclipse.tycho.extras:tycho-pack200a-plugin:2.7.5:normalize (pack200-normalize) on project mirroring: Execution pack200-normalize of goal org.eclipse.tycho.extras:tycho-pack200a-plugin:2.7.5:normalize failed: Unable to load the mojo 'normalize' in the plugin 'org.eclipse.tycho.extras:tycho-pack200a-plugin:2.7.5'. A required class is missing: org/codehaus/plexus/util/cli/CommandLineException
```