### PR TITLE
Stop pack200 building

### DIFF
--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -74,16 +74,6 @@
           <version>${tycho-version}</version>
         </plugin>
         <plugin>
-          <groupId>org.eclipse.tycho.extras</groupId>
-          <artifactId>tycho-pack200a-plugin</artifactId>
-          <version>${tycho-version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.tycho.extras</groupId>
-          <artifactId>tycho-pack200b-plugin</artifactId>
-          <version>${tycho-version}</version>
-        </plugin>
-        <plugin>
           <groupId>${tycho-groupid}</groupId>
           <artifactId>tycho-versions-plugin</artifactId>
           <version>${tycho-version}</version>
@@ -253,19 +243,6 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-pack200a-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>pack200-normalize</id>
-                <goals>
-                  <goal>normalize</goal>
-                </goals>
-                <phase>package</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.eclipse.cbi.maven.plugins</groupId>
             <artifactId>eclipse-jarsigner-plugin</artifactId>
             <executions>
@@ -280,19 +257,6 @@
             <configuration>
               <excludeInnerJars>${signExcludeInnerJars}</excludeInnerJars>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.eclipse.tycho.extras</groupId>
-            <artifactId>tycho-pack200b-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>pack200-pack</id>
-                <goals>
-                  <goal>pack</goal>
-                </goals>
-                <phase>package</phase>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <groupId>${tycho-groupid}</groupId>


### PR DESCRIPTION
Tycho removed it in version 3
(https://github.com/eclipse-tycho/tycho/blob/main/RELEASE_NOTES.md#pack200 ).
Eclipse removed entirely and has been a no-op since 4.16 (2020-06) https://www.eclipse.org/lists/cross-project-issues-dev/msg18273.html . Java removed it since Java 14 https://openjdk.org/jeps/367 and was marked for removal since Java 11.
This is a prereq for moving the build to Tycho 3.