### PR TITLE
Trying to isolate build pods

### DIFF
--- a/releng/Jenkinsfile.groovy
+++ b/releng/Jenkinsfile.groovy
@@ -15,6 +15,7 @@ class Build implements Serializable {
   private final String BUILD_CONTAINER_NAME="ubuntu"
   private final String BUILD_CONTAINER="""
     - name: $BUILD_CONTAINER_NAME
+      imagePullPolicy: Always
       image: basilevs/ubuntu-rcptt:3.6.2
       tty: true
       resources:


### PR DESCRIPTION
https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5641#note_3255644
This allows Jenkins Kubernetes to work with mutable Docker tags.