### PR TITLE
Fix pipeline warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 def library
 node {
   checkout scm
-  result = load('releng/Jenkinsfile.groovy')(this)
+  def result = load('releng/Jenkinsfile.groovy')(this)
   assert result != null
   library = result
 }

--- a/releng/Jenkinsfile
+++ b/releng/Jenkinsfile
@@ -1,7 +1,7 @@
 def build
 node {
   checkout scm
-  result = load('releng/Jenkinsfile.groovy')(this)
+  def result = load('releng/Jenkinsfile.groovy')(this)
   assert result != null
   build = result
 }


### PR DESCRIPTION
> Did you forget the `def` keyword? WorkflowScript seems to be setting a field named result (to a value of type Build) which could lead to memory leaks or other issues.