### PR TITLE
Bug 580941: Fix default value handling for OVERRIDE_SECURE_STORAGE

### DIFF
--- a/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/ext/Q7ExternalLaunchDelegate.java
+++ b/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/ext/Q7ExternalLaunchDelegate.java
@@ -523,9 +523,8 @@ public class Q7ExternalLaunchDelegate extends
 		} catch (IOException e) {
 			throw new CoreException(Q7ExtLaunchingPlugin.status(e));
 		}
-		String override = configuration.getAttribute(
-				IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-		if ("true".equals(override)) {
+		if ( configuration.getAttribute(
+				IQ7Launch.OVERRIDE_SECURE_STORAGE, true)) {
 			// Override existing parameter
 			programArgs.add("-eclipse.keyring");
 			programArgs.add(getConfigDir(configuration).toString()

--- a/modules/rap/bundles/launching/org.eclipse.rcptt.launching.rap/src/org/eclipse/rcptt/launching/rap/RcpttRapLaunchDelegate.java
+++ b/modules/rap/bundles/launching/org.eclipse.rcptt.launching.rap/src/org/eclipse/rcptt/launching/rap/RcpttRapLaunchDelegate.java
@@ -479,9 +479,8 @@ public class RcpttRapLaunchDelegate extends EquinoxLaunchConfiguration {
 		} catch (IOException e) {
 			throw new CoreException(Q7ExtLaunchingPlugin.status(e));
 		}
-		String override = configuration.getAttribute(
-				IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-		if (override == null || "true".equals(override)) {
+		if (configuration.getAttribute(
+				IQ7Launch.OVERRIDE_SECURE_STORAGE, true)) {
 			// Override existing parameter
 			programArguments.add("-eclipse.keyring");
 			programArguments.add(getConfigDir(configuration).toString()

--- a/rcp/org.eclipse.rcptt.launching.configuration/src/org/eclipse/rcptt/launching/configuration/Q7LaunchConfigurationDelegate.java
+++ b/rcp/org.eclipse.rcptt.launching.configuration/src/org/eclipse/rcptt/launching/configuration/Q7LaunchConfigurationDelegate.java
@@ -247,9 +247,8 @@ public class Q7LaunchConfigurationDelegate extends
 		} catch (IOException e) {
 			throw new CoreException(Q7ExtLaunchingPlugin.status(e));
 		}
-		String override = configuration.getAttribute(
-				IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-		if ("true".equals(override)) {
+		if (configuration.getAttribute(
+				IQ7Launch.OVERRIDE_SECURE_STORAGE, true)) {
 			// Override existing parameter
 			programArgs.add("-eclipse.keyring");
 			programArgs.add(getConfigDir(configuration).toString()

--- a/rcp/org.eclipse.rcptt.launching.ext.ui/src/org/eclipse/rcptt/internal/launching/ext/ui/AUTArgumentsTab.java
+++ b/rcp/org.eclipse.rcptt.launching.ext.ui/src/org/eclipse/rcptt/internal/launching/ext/ui/AUTArgumentsTab.java
@@ -11,6 +11,8 @@
 package org.eclipse.rcptt.internal.launching.ext.ui;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jdt.debug.ui.launchConfigurations.JavaArgumentsTab;
@@ -33,6 +35,7 @@ import org.eclipse.swt.widgets.Text;
 public class AUTArgumentsTab extends JavaArgumentsTab implements IAUTListener {
 	Text vmArguments;
 	Button secureStorage;
+	private static final ILog LOG = Platform.getLog(AUTArgumentsTab.class);
 
 	@Override
 	protected VMArgumentsBlock createVMArgsBlock() {
@@ -57,10 +60,12 @@ public class AUTArgumentsTab extends JavaArgumentsTab implements IAUTListener {
 			public void initializeFrom(ILaunchConfiguration configuration) {
 				super.initializeFrom(configuration);
 				try {
-					String value = configuration.getAttribute(
-							IQ7Launch.OVERRIDE_SECURE_STORAGE, (String) null);
-					secureStorage.setSelection(value == null);
+					boolean value = configuration.getAttribute(
+							IQ7Launch.OVERRIDE_SECURE_STORAGE, true);
+					secureStorage.setSelection(value);
 				} catch (CoreException e) {
+					LOG.error("FAiled to read " + IQ7Launch.OVERRIDE_SECURE_STORAGE + "attribute"  , e);
+					throw new IllegalArgumentException(e);
 				}
 			}
 
@@ -72,7 +77,7 @@ public class AUTArgumentsTab extends JavaArgumentsTab implements IAUTListener {
 							.removeAttribute(IQ7Launch.OVERRIDE_SECURE_STORAGE);
 				} else {
 					configuration.setAttribute(
-							IQ7Launch.OVERRIDE_SECURE_STORAGE, "false");
+							IQ7Launch.OVERRIDE_SECURE_STORAGE, false);
 				}
 				super.performApply(configuration);
 

--- a/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AutThread.java
+++ b/runner/org.eclipse.rcptt.runner/src/org/eclipse/rcptt/runner/util/AutThread.java
@@ -192,9 +192,7 @@ public class AutThread extends Thread {
 			config.setAttribute(IQ7Launch.ATTR_HEADLESS_LAUNCH, true);
 			config.setAttribute(DebugPlugin.ATTR_CAPTURE_OUTPUT, true);
 
-			if (!conf.overrideSecurityStorage) {
-				config.setAttribute(IQ7Launch.OVERRIDE_SECURE_STORAGE, "false");
-			}
+			config.setAttribute(IQ7Launch.OVERRIDE_SECURE_STORAGE, !conf.overrideSecurityStorage);
 
 			config.setAttribute(IQ7Launch.ATTR_OUT_FILE, outFilePath);
 			final String vmArgs = Q7LaunchDelegateUtils.getJoinedVMArgs(tpc.getTargetPlatform(),


### PR DESCRIPTION
This fixes a regression introduced in
2d132a197e4f3bbfe5de9ac413803f24e4548e71

The default value handling is required, because AUTArgumentsTab specifically deletes values matching the default.