### PR TITLE
Fix Status loss for DebugException #92

### DIFF
--- a/ecl/plugins/org.eclipse.rcptt.ecl.core/src/org/eclipse/rcptt/ecl/internal/core/ProcessStatusConverter.java
+++ b/ecl/plugins/org.eclipse.rcptt.ecl.core/src/org/eclipse/rcptt/ecl/internal/core/ProcessStatusConverter.java
@@ -164,6 +164,9 @@ public class ProcessStatusConverter implements
 		} catch (ClassNotFoundException e) {
 			suppressed.add(e);
 			clazz = IOException.class;
+			if (exception.getStatus() != null) {
+				clazz = CoreException.class;
+			}
 		}
 
 		Optional<Throwable> result;


### PR DESCRIPTION
Reports contain following truncated trace:

```
java.io.IOException: Terminate failed
	at org.eclipse.debug.core.Launch.terminate(Launch.java:298)
	at org.eclipse.rcptt.debug.runtime.DebugContextProcessor$3.run(DebugContextProcessor.java:312)
	at java.lang.Thread.run(Thread.java:1583)
```