### PR TITLE
Fix tiny heap sizes set by default

### DIFF
--- a/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/internal/launching/ext/UpdateVMArgs.java
+++ b/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/internal/launching/ext/UpdateVMArgs.java
@@ -122,7 +122,6 @@ public class UpdateVMArgs {
 
 	public static List<String> updateAttr(List<String> attribute) {
 		List<String> result = Lists.newArrayList(attribute);
-		addIfAbsent(result, "-Xmx", "512m");
 		// -XstartOnFirstThread
 		// -Dorg.eclipse.swt.internal.carbon.smallFonts
 		if (Platform.getOS().equals(Platform.OS_MACOSX)) {

--- a/rcpttTests/pom.xml
+++ b/rcpttTests/pom.xml
@@ -82,7 +82,6 @@
             <version>${runner-version}</version>
 						<vmArgs>
 							<vmArg>-XX:+HeapDumpOnOutOfMemoryError</vmArg>
-							<vmArg>-Xmx600M</vmArg>
 						</vmArgs>
           </runner>
           <skipTags>


### PR DESCRIPTION
See https://github.com/eclipse-packaging/packages/issues/37 as modern Java VMs are pretty good at managing the heap size automatically. Restricting to tiny heap sizes also clashes with `-XX:+UseG1GC` which is the default for Eclipse RCP based IDEs now.