### PR TITLE
Remove unrecognized includePacked parameter

### DIFF
--- a/dependencies/bundles/org.eclipse.rcptt.updates.aspectj.e44x/pom.xml
+++ b/dependencies/bundles/org.eclipse.rcptt.updates.aspectj.e44x/pom.xml
@@ -71,8 +71,6 @@
 	      <mirrorMetadataOnly>false</mirrorMetadataOnly>
 	      <compress>true</compress>
 	      <append>false</append>
-	      <includePacked>false</includePacked>
-
 	      <ius>
 		<iu><id>org.aspectj.runtime</id></iu>
 		<iu><id>org.aspectj.weaver</id></iu>

--- a/dependencies/bundles/org.eclipse.rcptt.updates.external.dependencies.rap/pom.xml
+++ b/dependencies/bundles/org.eclipse.rcptt.updates.external.dependencies.rap/pom.xml
@@ -68,7 +68,6 @@
         	  <mirrorMetadataOnly>false</mirrorMetadataOnly>
         	  <compress>true</compress>
         	  <append>false</append>
-        	  <includePacked>false</includePacked>
         	  <ius>
               <iu><id>org.eclipse.emf.common.feature.group</id></iu>
               <iu><id>org.eclipse.emf.databinding.edit.feature.group</id></iu>

--- a/dependencies/bundles/org.eclipse.rcptt.updates.extra/pom.xml
+++ b/dependencies/bundles/org.eclipse.rcptt.updates.extra/pom.xml
@@ -68,8 +68,6 @@
 	  <mirrorMetadataOnly>false</mirrorMetadataOnly>
 	  <compress>true</compress>
 	  <append>false</append>
-	  <includePacked>false</includePacked>
-
 	  <ius>
 	    <iu><id>org.apache.poi</id></iu>
 	    <iu><id>org.apache.poi.ooxml</id></iu>

--- a/dependencies/bundles/org.eclipse.rcptt.updates.kepler/pom.xml
+++ b/dependencies/bundles/org.eclipse.rcptt.updates.kepler/pom.xml
@@ -68,8 +68,6 @@
 	  <mirrorMetadataOnly>false</mirrorMetadataOnly>
 	  <compress>true</compress>
 	  <append>false</append>
-	  <includePacked>false</includePacked>
-
 	  <ius>
 	    <iu><id>org.eclipse.emf.codegen.ecore.ui.feature.group</id></iu>
             <iu><id>org.eclipse.emf.codegen.ecore.feature.group</id></iu>


### PR DESCRIPTION
It's no longer supported by Tycho version used in the build. Fixes many "[WARNING] Parameter 'includePacked' is unknown for plugin 'tycho-p2-extras-plugin:4.0.12:mirror (mirror-update-site)'" in the build.