### PR TITLE
Sync JDT settings

### DIFF
--- a/ecl/plugins/org.eclipse.rcptt.ecl.data/.classpath
+++ b/ecl/plugins/org.eclipse.rcptt.ecl.data/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="gen-src"/>
 	<classpathentry kind="src" path="src"/>

--- a/ecl/plugins/org.eclipse.rcptt.ecl.data/.settings/org.eclipse.jdt.core.prefs
+++ b/ecl/plugins/org.eclipse.rcptt.ecl.data/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,7 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=1.8

--- a/launching/org.eclipse.rcptt.reporting.util/.settings/org.eclipse.jdt.core.prefs
+++ b/launching/org.eclipse.rcptt.reporting.util/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17


### PR DESCRIPTION
JDT no longer supports generation of pre 1.8 bytecode (https://eclipse.dev/eclipse/news/news.html?file=4.33/jdt.html#removed-support-for-java7-and-below ). Such cases are silently treated as 1.8.

Also put o.e.jdt.core.prefs files in git control in order to be sure that JDT is fully instructed what to do based on content of Manifest file.