### PR TITLE
Stop passing "--launcher.GTK_version 2"

### DIFF
--- a/devenv/launches/RCPTT IDE.launch
+++ b/devenv/launches/RCPTT IDE.launch
@@ -24,7 +24,7 @@
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_SHOW_CODEDETAILS_IN_EXCEPTION_MESSAGES" value="true"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -showsplash org.eclipse.rcptt.platform -nosplash --launcher.GTK_version 2"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -showsplash org.eclipse.rcptt.platform -nosplash"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m -Xmx768m -Dorg.eclipse.swt.browser.DefaultType=mozilla -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false&#10;-XX:+HeapDumpOnOutOfMemoryError"/>
     <stringAttribute key="pde.version" value="3.3"/>


### PR DESCRIPTION
It doesn't harm but at the same time causes confusion and the option hasn't been supported for years.