### PR TITLE
Stop using Guava's deprecated Charsets

### DIFF
--- a/ecl/tests/org.eclipse.rcptt.ecl.parser.test/src/org/eclipse/rcptt/ecl/parser/test/TestSession.java
+++ b/ecl/tests/org.eclipse.rcptt.ecl.parser.test/src/org/eclipse/rcptt/ecl/parser/test/TestSession.java
@@ -13,6 +13,7 @@ package org.eclipse.rcptt.ecl.parser.test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -23,7 +24,6 @@ import org.eclipse.rcptt.ecl.runtime.IPipe;
 import org.eclipse.rcptt.ecl.runtime.IProcess;
 import org.eclipse.rcptt.ecl.runtime.ISession;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 
 public class TestSession {
@@ -59,7 +59,7 @@ public class TestSession {
 
 	public static String toString(InputStream is) throws IOException {
 		try {
-			return CharStreams.toString(new InputStreamReader(is, Charsets.UTF_8));
+			return CharStreams.toString(new InputStreamReader(is, StandardCharsets.UTF_8));
 		} finally {
 			is.close();
 		}

--- a/launching/org.eclipse.rcptt.launching/src/org/eclipse/rcptt/internal/launching/aut/OutputCaptureLaunchListener.java
+++ b/launching/org.eclipse.rcptt.launching/src/org/eclipse/rcptt/internal/launching/aut/OutputCaptureLaunchListener.java
@@ -14,6 +14,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.eclipse.debug.core.IStreamListener;
@@ -22,7 +23,6 @@ import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.core.model.IStreamMonitor;
 import org.eclipse.debug.core.model.IStreamsProxy;
 
-import com.google.common.base.Charsets;
 import org.eclipse.rcptt.core.launching.events.AutBundleState;
 import org.eclipse.rcptt.internal.launching.Q7LaunchingPlugin;
 import org.eclipse.rcptt.launching.AutLaunch;
@@ -58,7 +58,7 @@ public class OutputCaptureLaunchListener implements AutLaunchListener {
 			if (listener == null) {
 				this.listener = new PrintStreamListener(new PrintStream(
 						new FileOutputStream(logFile, true), true,
-						Charsets.UTF_8.name()));
+						StandardCharsets.UTF_8.name()));
 			}
 
 			for (IProcess process : processes) {

--- a/launching/org.eclipse.rcptt.reporting.html/src/org/eclipse/rcptt/reporting/html/HtmlReportRenderer.java
+++ b/launching/org.eclipse.rcptt.reporting.html/src/org/eclipse/rcptt/reporting/html/HtmlReportRenderer.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package org.eclipse.rcptt.reporting.html;
 
-import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Predicates.compose;
 import static com.google.common.base.Predicates.equalTo;
 import static com.google.common.base.Predicates.not;
@@ -22,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.text.NumberFormat;
 
 import org.eclipse.core.runtime.CoreException;
@@ -38,7 +38,6 @@ import org.eclipse.rcptt.sherlock.core.model.sherlock.report.Report;
 import org.eclipse.rcptt.sherlock.core.model.sherlock.report.Screenshot;
 import org.eclipse.rcptt.util.FileUtil;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Strings;
@@ -57,7 +56,7 @@ public class HtmlReportRenderer implements IReportRenderer {
 	static String loadAsString(String path) {
 		try {
 			byte[] content = FileUtil.getStreamContent(HtmlReportRenderer.class.getResourceAsStream(path));
-			return new String(content, UTF_8);
+			return new String(content, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException("Failed to load " + path);
 		}
@@ -69,7 +68,7 @@ public class HtmlReportRenderer implements IReportRenderer {
 		PrintWriter writer = null;
 		try {
 			OutputStream stream = factory.createFileStream(reportName + ".html");
-			writer = new PrintWriter(new OutputStreamWriter(stream, Charsets.UTF_8));
+			writer = new PrintWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8));
 			renderReport(writer, reportList, factory);
 		} catch (Exception e) {
 			return Plugin.UTILS.createError(e);

--- a/launching/org.eclipse.rcptt.reporting.html/src/org/eclipse/rcptt/reporting/html/HtmlReporter.java
+++ b/launching/org.eclipse.rcptt.reporting.html/src/org/eclipse/rcptt/reporting/html/HtmlReporter.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -24,7 +25,6 @@ import org.eclipse.rcptt.sherlock.core.model.sherlock.report.Node;
 import org.eclipse.rcptt.sherlock.core.model.sherlock.report.Report;
 import org.eclipse.rcptt.util.FileUtil;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 
 public class HtmlReporter extends HtmlReportRenderer {
@@ -76,7 +76,7 @@ public class HtmlReporter extends HtmlReportRenderer {
 		PrintWriter childWriter = null;
 		try {
 			OutputStream os = content.createFileStream(fileName);
-			childWriter = new PrintWriter(new OutputStreamWriter(os, Charsets.UTF_8));
+			childWriter = new PrintWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
 			childWriter.println("<html>");
 			renderHead(childWriter, root.getName());
 			childWriter.println("<body onload=\"installDetailsWorkaround()\">");

--- a/launching/tests/org.eclipse.rcptt.reporting.html.tests/src/org/eclipse/rcptt/reporting/html/tests/VolatileContentFactory.java
+++ b/launching/tests/org.eclipse.rcptt.reporting.html.tests/src/org/eclipse/rcptt/reporting/html/tests/VolatileContentFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.rcptt.reporting.html.tests;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +21,6 @@ import java.util.Map;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.rcptt.internal.core.RcpttPlugin;
 import org.eclipse.rcptt.reporting.core.IReportRenderer.IContentFactory;
-
-import com.google.common.base.Charsets;
 
 public class VolatileContentFactory implements IContentFactory {
 	private final Map<String, byte[]> data;
@@ -77,6 +76,6 @@ public class VolatileContentFactory implements IContentFactory {
 	}
 
 	public String read(String path) {
-		return new String(data.get(createKey(path)), Charsets.UTF_8);
+		return new String(data.get(createKey(path)), StandardCharsets.UTF_8);
 	}
 }

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/editors/PropertyCellEditor.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/editors/PropertyCellEditor.java
@@ -14,6 +14,7 @@ package org.eclipse.rcptt.ui.editors;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.TreeSet;
@@ -68,7 +69,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.ISharedImages;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
 @SuppressWarnings("restriction")
@@ -538,7 +538,7 @@ public class PropertyCellEditor extends TextCellEditor {
 			if (url == null) {
 				return styles = "";
 			}
-			return styles = Resources.toString(url, Charsets.UTF_8);
+			return styles = Resources.toString(url, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			Q7UIPlugin.log(e);
 			return styles = "";

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/editors/ecl/EclInformationContol.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/editors/ecl/EclInformationContol.java
@@ -12,6 +12,7 @@ package org.eclipse.rcptt.ui.editors.ecl;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jface.internal.text.html.BrowserInformationControl;
 import org.eclipse.jface.internal.text.html.HTMLPrinter;
@@ -19,7 +20,6 @@ import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Shell;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 
@@ -70,7 +70,7 @@ public class EclInformationContol extends BrowserInformationControl {
 			if (url == null) {
 				return styles = "";
 			}
-			return styles = Resources.toString(url, Charsets.UTF_8);
+			return styles = Resources.toString(url, StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			Q7UIPlugin.log(e);
 			return styles = "";

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/launching/ResourceLaunchConfigurationMigration.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/launching/ResourceLaunchConfigurationMigration.java
@@ -23,6 +23,7 @@ import java.io.FilenameFilter;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -51,7 +52,6 @@ import org.eclipse.rcptt.util.FileUtil;
 import org.eclipse.ui.IStartup;
 import org.w3c.dom.Document;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
 
@@ -102,7 +102,7 @@ public class ResourceLaunchConfigurationMigration implements IStartup {
 			Writer writer = new StringWriter();
 			LaunchConfigurationMigration.write(document, writer);
 			resource.setContents(new ByteArrayInputStream(writer.toString()
-					.getBytes(Charsets.UTF_8)), 0, null);
+					.getBytes(StandardCharsets.UTF_8)), 0, null);
 		}
 	}
 


### PR DESCRIPTION
Replaced with java NIO's StandardCharsets for which Charsets members are aliases for.