### PR TITLE
Build with Tycho 4.0.13

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-build</artifactId>
-        <version>4.0.12</version>
+        <version>4.0.13</version>
     </extension>
 </extensions>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -24,7 +24,7 @@
   </licenses>
   
   <properties>
-    <tycho-version>4.0.12</tycho-version>
+    <tycho-version>4.0.13</tycho-version>
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ajdt43repository>http://download.eclipse.org/tools/ajdt/431/dev/update/</ajdt43repository>


### PR DESCRIPTION
Full release notes available at
https://github.com/eclipse-tycho/tycho/blob/tycho-4.0.13/RELEASE_NOTES.md .
One of the important features is that now it works with Java 24 thanks to updated dependencies that fix
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2623 .