### PR TITLE
Revert "Update Tycho to 5.0.0"

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
     <extension>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-build</artifactId>
-        <version>5.0.0</version>
+        <version>4.0.13</version>
     </extension>
 </extensions>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -24,7 +24,7 @@
   </licenses>
   
   <properties>
-    <tycho-version>5.0.0</tycho-version>
+    <tycho-version>4.0.13</tycho-version>
     <tycho-groupid>org.eclipse.tycho</tycho-groupid>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ajdt43repository>http://download.eclipse.org/tools/ajdt/431/dev/update/</ajdt43repository>


### PR DESCRIPTION
Reverts eclipse-rcptt/org.eclipse.rcptt#225

Tycho 5.0.0 fails to run surefire tests on Jenkins. For some reason, the tests are working fine in Github Actions.

```
java.lang.RuntimeException: Unable to create test class 'org.eclipse.rcptt.ecl.parser.test.ExecServiceTest'
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:117)
	at org.apache.maven.surefire.api.util.DefaultScanResult.applyFilter(DefaultScanResult.java:85)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.scanClassPath(JUnitCoreProvider.java:254)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.setTestsToRun(JUnitCoreProvider.java:180)
	at org.apache.maven.surefire.junitcore.JUnitCoreProvider.invoke(JUnitCoreProvider.java:124)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.apache.maven.surefire.api.util.ReflectionUtils.invokeMethodWithArray2(ReflectionUtils.java:137)
	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:148)
	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:88)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.invokeSureFire(OsgiSurefireBooter.java:195)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.tycho.surefire.osgibooter.OsgiSurefireBooter.run(OsgiSurefireBooter.java:116)
	at org.eclipse.tycho.surefire.osgibooter.HeadlessTestApplication.start(HeadlessTestApplication.java:29)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:203)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:136)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:401)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:255)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:659)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:596)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1467)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1440)
Caused by: java.lang.ClassNotFoundException: org.eclipse.rcptt.ecl.parser.test.ExecServiceTest cannot be found by org.eclipse.tycho.surefire.osgibooter_5.0.0
	at org.eclipse.osgi.internal.loader.BundleLoader.generateException(BundleLoader.java:516)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:511)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:403)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	at org.apache.maven.surefire.api.util.DefaultScanResult.loadClass(DefaultScanResult.java:115)
	... 25 more
```
[config.ini.txt](https://github.com/user-attachments/files/23598383/config.ini.txt)
