### PR TITLE
Use PlatformUI.getWorkbench directly

### DIFF
--- a/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/ObsoleteEclFormatDialog.java
+++ b/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/ObsoleteEclFormatDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -14,7 +14,7 @@ import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.rcptt.core.scenario.Scenario;
 import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.preferences.IPreferenceKeys;
@@ -31,8 +31,7 @@ public enum ObsoleteEclFormatDialog {
 		if (MessageDialogWithToggle.ALWAYS.equals(show)) {
 			Display.getDefault().syncExec(new Runnable() {
 				public void run() {
-					IWorkbenchWindow window = Q7UIPlugin.getDefault()
-							.getWorkbench().getActiveWorkbenchWindow();
+					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 					MessageDialogWithToggle dialog = MessageDialogWithToggle
 							.openInformation(window.getShell(), "Error",
 									"Oops! Test case \"" + scenario.getName()

--- a/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/RecoverEclWarningDialog.java
+++ b/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/RecoverEclWarningDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.preferences.IPreferenceKeys;
 
@@ -34,8 +34,7 @@ public enum RecoverEclWarningDialog {
 		final boolean[] answer = new boolean[1];
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				IWorkbenchWindow window = Q7UIPlugin.getDefault()
-						.getWorkbench().getActiveWorkbenchWindow();
+				IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 				MessageDialogWithToggle dialog = MessageDialogWithToggle
 						.openOkCancelConfirm(window.getShell(), "Warning",
 								"All user changes will be discarded.\n"

--- a/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/UserModificationDialog.java
+++ b/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/dialogs/UserModificationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -15,7 +15,7 @@ import org.eclipse.jface.dialogs.MessageDialogWithToggle;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.rcptt.core.scenario.Scenario;
 import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.preferences.IPreferenceKeys;
@@ -33,8 +33,7 @@ public enum UserModificationDialog {
 			final boolean[] answer = new boolean[1];
 			Display.getDefault().syncExec(new Runnable() {
 				public void run() {
-					IWorkbenchWindow window = Q7UIPlugin.getDefault()
-							.getWorkbench().getActiveWorkbenchWindow();
+					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 					MessageDialogWithToggle dialog = MessageDialogWithToggle
 							.openYesNoQuestion(window.getShell(), "Error",
 									"Test case \"" + scenario.getName()

--- a/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/handlers/StatisticsHandler.java
+++ b/rcp/org.eclipse.rcptt.dev.ui/src/org/eclipse/rcptt/dev/ui/handlers/StatisticsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -13,12 +13,11 @@ package org.eclipse.rcptt.dev.ui.handlers;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.rcptt.core.Scenarios;
 import org.eclipse.rcptt.core.model.ITestCase;
 import org.eclipse.rcptt.core.model.ModelException;
 import org.eclipse.rcptt.core.scenario.Scenario;
-import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.actions.ScenariosActionHandler;
 
 public class StatisticsHandler extends ScenariosActionHandler {
@@ -53,8 +52,7 @@ public class StatisticsHandler extends ScenariosActionHandler {
 
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				IWorkbenchWindow window = Q7UIPlugin.getDefault()
-						.getWorkbench().getActiveWorkbenchWindow();
+				IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 				MessageDialog.openInformation(window.getShell(), "Statistics",
 						message.toString());
 			}

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/RefactoringSaveHelper.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/RefactoringSaveHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -27,10 +27,10 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ListDialog;
 
 import org.eclipse.rcptt.internal.ui.Messages;
-import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 
 public class RefactoringSaveHelper {
 
@@ -66,8 +66,7 @@ public class RefactoringSaveHelper {
 
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				IWorkbenchWindow window = Q7UIPlugin.getDefault()
-						.getWorkbench().getActiveWorkbenchWindow();
+				IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 				if (window == null)
 					return;
 				IWorkbenchPage page = window.getActivePage();

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/delete/DeleteQ7ElementProcessor.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/delete/DeleteQ7ElementProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -46,7 +46,7 @@ import org.eclipse.rcptt.internal.ui.Messages;
 import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.refactoring.ResourceAccessChange;
 import org.eclipse.rcptt.ui.utils.WriteAccessChecker;
-import org.eclipse.ui.internal.UIPlugin;
+import org.eclipse.ui.PlatformUI;
 
 @SuppressWarnings("restriction")
 public class DeleteQ7ElementProcessor extends DeleteResourcesProcessor {
@@ -81,7 +81,7 @@ public class DeleteQ7ElementProcessor extends DeleteResourcesProcessor {
 		this.resources = resources;
 
 		try {
-			UIPlugin.getDefault().getWorkbench().getProgressService().
+			PlatformUI.getWorkbench().getProgressService().
 					run(true, false, new ReferenceCollector());
 
 			/*

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/rename/RenameContainerChange.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/refactoring/rename/RenameContainerChange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -29,9 +29,8 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
-
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.rcptt.internal.ui.Messages;
-import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.editors.NamedElementEditor;
 
 public class RenameContainerChange extends ResourceChange {
@@ -194,8 +193,7 @@ public class RenameContainerChange extends ResourceChange {
 	private void updateEditorInputs(final IPath newPath) {
 		Display.getDefault().syncExec(new Runnable() {
 			public void run() {
-				IWorkbenchWindow window = Q7UIPlugin.getDefault()
-						.getWorkbench().getActiveWorkbenchWindow();
+				IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 				if (window == null)
 					return;
 				IWorkbenchPage page = window.getActivePage();

--- a/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/utils/ModelUtils.java
+++ b/rcp/org.eclipse.rcptt.ui/src/org/eclipse/rcptt/ui/utils/ModelUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2009, 2019 Xored Software Inc and others.
+ * Copyright (c) 2009, 2025 Xored Software Inc and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
@@ -37,7 +37,6 @@ import org.eclipse.rcptt.core.scenario.Verification;
 import org.eclipse.rcptt.core.workspace.Q7Utils;
 import org.eclipse.rcptt.internal.core.RcpttPlugin;
 import org.eclipse.rcptt.internal.ui.Images;
-import org.eclipse.rcptt.internal.ui.Q7UIPlugin;
 import org.eclipse.rcptt.ui.context.ContextUIManager;
 import org.eclipse.rcptt.ui.context.ContextViewer;
 import org.eclipse.rcptt.ui.editors.INamedElementEditor;
@@ -49,6 +48,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.FileEditorInput;
 
 public class ModelUtils {
@@ -232,8 +232,7 @@ public class ModelUtils {
 			Display.getDefault().syncExec(new Runnable() {
 				public void run() {
 					FileEditorInput input = new FileEditorInput(file);
-					IWorkbenchWindow window = Q7UIPlugin.getDefault().getWorkbench()
-							.getActiveWorkbenchWindow();
+					IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
 					if (window == null)
 						return;
 					IWorkbenchPage page = window.getActivePage();


### PR DESCRIPTION
AbstractUIPlugin.getWorkbench method is deprecated and marked for removal (in 2027-03 at earliest).