### PR TITLE
Don't log an error when a view can't be found by pattern

### DIFF
--- a/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.swt.rap/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
+++ b/modules/rap/bundles/runtime/tesla/org.eclipse.rcptt.tesla.swt.rap/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
@@ -740,13 +740,10 @@ public final class SWTUIPlayer {
 					currIdx++;
 				}
 			} catch (Exception e) {
-				// Skip brokeb parts.
+				// Skip broken parts.
 				TeslaCore.log(e);
 			}
 		}
-
-		TeslaCore.log("Can not find view by pattern \"" + pattern
-				+ "\". Activating views...");
 
 		// Not found, lets go with resolve of view parts, it will initialize
 		// titles.
@@ -766,6 +763,7 @@ public final class SWTUIPlayer {
 				currIdx++;
 			}
 		}
+		TeslaCore.log("Can not find view by pattern \"" + pattern + "\".");
 		return null;
 	}
 

--- a/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
@@ -703,12 +703,10 @@ public final class SWTUIPlayer {
 					currIdx++;
 				}
 			} catch (Exception e) {
-				// Skip brokeb parts.
+				// Skip broken parts.
 				TeslaCore.log(e);
 			}
 		}
-
-		TeslaCore.log("Can not find view by pattern \"" + pattern + "\". Activating views...");
 
 		// Not found, lets go with resolve of view parts, it will initialize
 		// titles.
@@ -727,6 +725,7 @@ public final class SWTUIPlayer {
 				currIdx++;
 			}
 		}
+		TeslaCore.log("Can not find view by pattern \"" + pattern + "\".");
 		return null;
 	}
 


### PR DESCRIPTION
This will otherwise log plenty of errors like
> Can not find view by pattern "%LocalizedString". Activating views...

despite the script actually succeeding in the end.