### PR TITLE
Consider interfaces when searching for methods and fields #265

### DIFF
--- a/core/org.eclipse.rcptt.util/src/org/eclipse/rcptt/util/ReflectionUtil.java
+++ b/core/org.eclipse.rcptt.util/src/org/eclipse/rcptt/util/ReflectionUtil.java
@@ -133,6 +133,12 @@ public class ReflectionUtil {
 		} catch (NoSuchFieldException e) {
 			// check superclass
 		}
+		for (Class<?> clazz1 : clazz.getInterfaces()) {
+			Field result = findField(clazz1, name);
+			if (result != null) {
+				return result;
+			}
+		}
 		return findField(clazz.getSuperclass(), name);
 	}
 
@@ -156,6 +162,12 @@ public class ReflectionUtil {
 			return null;
 		} catch (NoSuchMethodException e) {
 			// check superclass
+		}
+		for (Class<?> clazz1 : clazz.getInterfaces()) {
+			Method result = findMethod(clazz1, name);
+			if (result != null) {
+				return result;
+			}
 		}
 		return findMethod(clazz.getSuperclass(), name, params);
 	}

--- a/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/swt/reflection/JavaMembersHelper.java
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/swt/reflection/JavaMembersHelper.java
@@ -11,6 +11,7 @@
 package org.eclipse.rcptt.tesla.swt.reflection;
 
 import static org.eclipse.rcptt.tesla.core.TeslaFeatures.isProtectedEnabled;
+import static java.lang.String.format;
 import static java.lang.reflect.Modifier.PROTECTED;
 import static java.lang.reflect.Modifier.PUBLIC;
 import static java.lang.reflect.Modifier.STATIC;
@@ -525,6 +526,10 @@ public class JavaMembersHelper {
 			}
 			Field field = ReflectionUtil.findField(object.getClass(),
 					memberName);
+			if (field == null) {
+				throw new IllegalArgumentException(format("Class: %s, field: %s",
+						object.getClass(), memberName));
+			}
 			Object value = field.get(object);
 			return new PropertyValue(object, value, memberName, field.getType());
 		}
@@ -546,6 +551,10 @@ public class JavaMembersHelper {
 
 			Method method = ReflectionUtil.findMethod(object.getClass(),
 					memberName);
+			if (method == null) {
+				throw new IllegalArgumentException(format("Class: %s, method: %s",
+						object.getClass(), memberName));
+			}
 			Object value = method.invoke(object);
 			return new PropertyValue(object, value, memberName,
 					method.getReturnType());

--- a/tests/org.eclipse.rcptt.core.tests/src/org/eclipse/rcptt/core/tests/util/ReflectionUtilTest.java
+++ b/tests/org.eclipse.rcptt.core.tests/src/org/eclipse/rcptt/core/tests/util/ReflectionUtilTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2026 DSA GmbH, Aachen and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ *     DSA GmbH, Aachen - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package org.eclipse.rcptt.core.tests.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.rcptt.util.ReflectionUtil;
+import org.junit.Test;
+
+public class ReflectionUtilTest {
+	@Test
+	public void testCallMethod1() {
+		List<String> test = List.of("value");
+		assertEquals(1, ReflectionUtil.callMethod(test, "size"));
+	}
+	
+	@Test
+	public void testCallMethod2() {
+		List<String> test = Collections.unmodifiableList(List.of("value"));
+		assertEquals(1, ReflectionUtil.callMethod(test, "size"));
+	}
+
+	@Test
+	public void testFindMethod1() {
+		assertNotNull(ReflectionUtil.findMethod(List.class, "size"));
+	}
+
+	@Test
+	public void testFindMethod2() {
+		List<String> test = Collections.unmodifiableList(List.of("value"));
+		assertNotNull(ReflectionUtil.findMethod(test.getClass(), "size"));
+	}
+
+	@Test
+	public void testGetField() {
+		Path p = new Path("");
+		assertEquals(IPath.SEPARATOR, ReflectionUtil.getField(p, "SEPARATOR"));
+	}
+
+	@Test
+	public void testFindField() {
+		assertNotNull(ReflectionUtil.findField(IFile.class, "DEPTH_INFINITE"));
+	}
+}


### PR DESCRIPTION
This is a continuation of 91cf9e80cdbec4df87a117177a99a3296692e65d which extends the method/field search in the ReflectionUtil class. When searching for a public JDK method, no method may be found if all classes are private, even though the method itself is accessible via e.g. an interface.

An example of this is the UnmodifiableRandomAccessList with following hierarchy:

UnmodifiableRandomAccessList
-> UnmodifiableList
-> UnmodifiableCollection

All classes are package-private and thus trying to call `size()` via reflection is not possible, even though this method is public due to the `List` interface. To make this method accessible by RCPTT, the search must therefore not only check all super-classes but also all implemented interfaces.

Additionally, checks have been added to the `JavaMembersHelper`, which produce a more descriptive error message, rather than failing with a plain `NullPointerException`.