### PR TITLE
Clean launch configs from ancient properties

### DIFF
--- a/devenv/launches/RCPTT IDE AUT.launch
+++ b/devenv/launches/RCPTT IDE AUT.launch
@@ -25,7 +25,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Xms128m &#13;&#10;-Xmx768m &#13;&#10;-Dorg.eclipse.swt.browser.DefaultType=mozilla &#13;&#10;-Dorg.eclipse.swt.internal.gtk.cairoGraphics=false&#13;&#10;-DteslaPort=7927 &#13;&#10;-DeclPort=5379 &#13;&#10;-Dosgi.framework.extensions=org.eclipse.equinox.weaving.hook&#10;--add-opens java.base/java.lang=ALL-UNNAMED"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Xms128m &#13;&#10;-Xmx768m &#13;&#10;-DteslaPort=7927 &#13;&#10;-DeclPort=5379 &#13;&#10;-Dosgi.framework.extensions=org.eclipse.equinox.weaving.hook&#10;--add-opens java.base/java.lang=ALL-UNNAMED"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <setAttribute key="selected_target_bundles">

--- a/devenv/launches/RCPTT IDE Self AUT.launch
+++ b/devenv/launches/RCPTT IDE Self AUT.launch
@@ -25,7 +25,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Xms128m &#13;&#10;-Xmx768m &#13;&#10;-Dorg.eclipse.swt.browser.DefaultType=mozilla &#13;&#10;-Dorg.eclipse.swt.internal.gtk.cairoGraphics=false&#13;&#10;-Dosgi.framework.extensions=org.eclipse.equinox.weaving.hook&#10;--add-opens java.base/java.lang=ALL-UNNAMED&#10;-DteslaPort=7928&#10;-DeclPort=5381"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true&#13;&#10;-Xms128m &#13;&#10;-Xmx768m &#13;&#10;-Dosgi.framework.extensions=org.eclipse.equinox.weaving.hook&#10;--add-opens java.base/java.lang=ALL-UNNAMED&#10;-DteslaPort=7928&#10;-DeclPort=5381"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.platform.ide"/>
     <setAttribute key="selected_target_bundles">

--- a/devenv/launches/RCPTT IDE.launch
+++ b/devenv/launches/RCPTT IDE.launch
@@ -26,7 +26,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-21"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -showsplash org.eclipse.rcptt.platform -nosplash"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m -Xmx768m -Dorg.eclipse.swt.browser.DefaultType=mozilla -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false&#10;-XX:+HeapDumpOnOutOfMemoryError"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xms128m -Xmx768m -XX:+HeapDumpOnOutOfMemoryError"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.rcptt.platform.product"/>
     <stringAttribute key="productFile" value="/org.eclipse.rcptt.ide/org.eclipse.rcptt.product"/>


### PR DESCRIPTION
Remove -Dorg.eclipse.swt.browser.DefaultType=[mozilla](https://github.com/eclipse-platform/eclipse.platform.swt/commit/13a201fc594576b80fcad1843401f006102a8268) -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false as they have been totally ignored in SWT since 2017.