### PR TITLE
Revert "Temporarily skip CloseUnrelatedProjectsInQ7Explorer due to upstream Eclipse Platform regression"

### DIFF
--- a/rcpttTests/rcptt_ide/platform_tests/q7Explorer/CloseUnrelatedProjectsInQ7Explorer.test
+++ b/rcpttTests/rcptt_ide/platform_tests/q7Explorer/CloseUnrelatedProjectsInQ7Explorer.test
@@ -8,7 +8,7 @@ External-Reference:
 Id: _n3bH8MmFEeCVO9X7TqWdlg
 Runtime-Version: 2.3.0.qualifier
 Save-Time: 5/11/18 3:07 PM
-Tags: Q7Explorer, Project, skipExecution
+Tags: Q7Explorer, Project
 Testcase-Type: ecl
 
 ------=_.description-216f885c-d591-38ce-8ea2-e4f8cb4d6ffa
@@ -24,9 +24,6 @@ https://www.eclipse.org/legal/epl-v20.html
 Contributors:
     Xored Software Inc - initial creation and/or initial documentation
 --------------------------------------------------------------------------------
-
-Note: skipExecution because of https://github.com/eclipse-platform/eclipse.platform.ui/pull/3871#issuecomment-4336933994.
-Re-enable this test after the Eclipse Platform fix (reverting this regression) reaches the staging repository.
 
 1. Select project with reference
 2. Select "Close Unrelated Projects" in context menu


### PR DESCRIPTION
Reverts eclipse-rcptt/org.eclipse.rcptt#318