### PR TITLE
Fix for Invalid Thread Access

### DIFF
--- a/runtime/ecl/org.eclipse.rcptt.tesla.ecl.impl/src/org/eclipse/rcptt/tesla/ecl/impl/UIRunnable.java
+++ b/runtime/ecl/org.eclipse.rcptt.tesla.ecl.impl/src/org/eclipse/rcptt/tesla/ecl/impl/UIRunnable.java
@@ -79,31 +79,26 @@ public abstract class UIRunnable<T> {
 				boolean tick = processed.get().equals(RunningState.Starting) || processed.get().equals(RunningState.Execution);
 				Q7WaitInfoRoot info = TeslaBridge.getCurrentWaitInfo(tick);
 				
-				boolean resultValue = true;
-				
 				if (!PlatformUI.getWorkbench().getDisplay()
 						.equals(Display.getCurrent())) {
 					Q7WaitUtils.updateInfo("display", "instance", info);
 					debugProceed("Wrong display");
-					resultValue = false;
+					return false;
 				}
 				// Return false if we have SWT observable in timers
 				if (SWTUIPlayer.hasTimers(display, info)) {
 					Q7WaitUtils.updateInfo("display", "timers", info);
 					debugProceed("Has timers");
-					resultValue = false;
+					return false;
 				}
 				// Check for asyncs in synchronizer
 				if (SWTUIPlayer.hasRunnables(display)) {
 					Q7WaitUtils.updateInfo("display", "runnables", info);
 					debugProceed("Has runnables");
-					resultValue = false;
+					return false;
 				}
 				if (!collector.isEmpty(currentContext, info)) {
 					debugProceed("Has jobs");
-					resultValue = false;
-				}
-				if( !resultValue ) {
 					return false;
 				}
 				if (processed.compareAndSet(RunningState.Starting, RunningState.Execution)) {

--- a/runtime/ecl/org.eclipse.rcptt.tesla.ecl.impl/src/org/eclipse/rcptt/tesla/ecl/impl/UIRunnable.java
+++ b/runtime/ecl/org.eclipse.rcptt.tesla.ecl.impl/src/org/eclipse/rcptt/tesla/ecl/impl/UIRunnable.java
@@ -79,26 +79,31 @@ public abstract class UIRunnable<T> {
 				boolean tick = processed.get().equals(RunningState.Starting) || processed.get().equals(RunningState.Execution);
 				Q7WaitInfoRoot info = TeslaBridge.getCurrentWaitInfo(tick);
 				
+				boolean resultValue = true;
+				
 				if (!PlatformUI.getWorkbench().getDisplay()
 						.equals(Display.getCurrent())) {
 					Q7WaitUtils.updateInfo("display", "instance", info);
 					debugProceed("Wrong display");
-					return false;
+					resultValue = false;
 				}
 				// Return false if we have SWT observable in timers
 				if (SWTUIPlayer.hasTimers(display, info)) {
 					Q7WaitUtils.updateInfo("display", "timers", info);
 					debugProceed("Has timers");
-					return false;
+					resultValue = false;
 				}
 				// Check for asyncs in synchronizer
-				if (SWTUIPlayer.hasRunnables(display)) {
+				if (resultValue && SWTUIPlayer.hasRunnables(display)) {
 					Q7WaitUtils.updateInfo("display", "runnables", info);
 					debugProceed("Has runnables");
-					return false;
+					resultValue = false;
 				}
 				if (!collector.isEmpty(currentContext, info)) {
 					debugProceed("Has jobs");
+					resultValue = false;
+				}
+				if( !resultValue ) {
 					return false;
 				}
 				if (processed.compareAndSet(RunningState.Starting, RunningState.Execution)) {

--- a/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
@@ -1767,15 +1767,6 @@ public final class SWTUIPlayer {
 	}
 
 	public boolean canProceed(Context context, Q7WaitInfoRoot info) {
-		if (display == null) {
-			debugProceed("Display is null. Probably execution in other thread.");
-			return false;
-		}
-		// check if current Display is disposed
-		if (display.isDisposed()) {
-			debugProceed("Display is disposed");
-			return false;
-		}		
 		if (!display.equals(Display.getCurrent())) {
 			// Q7WaitUtils.updateInfo("display", "non current", info);
 			debugProceed("Wrong display");

--- a/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
+++ b/runtime/tesla/org.eclipse.rcptt.tesla.swt/src/org/eclipse/rcptt/tesla/internal/ui/player/SWTUIPlayer.java
@@ -1767,6 +1767,15 @@ public final class SWTUIPlayer {
 	}
 
 	public boolean canProceed(Context context, Q7WaitInfoRoot info) {
+		if (display == null) {
+			debugProceed("Display is null. Probably execution in other thread.");
+			return false;
+		}
+		// check if current Display is disposed
+		if (display.isDisposed()) {
+			debugProceed("Display is disposed");
+			return false;
+		}		
 		if (!display.equals(Display.getCurrent())) {
 			// Q7WaitUtils.updateInfo("display", "non current", info);
 			debugProceed("Wrong display");


### PR DESCRIPTION
Executing tests using multiple UI treads (e.g. for additional windows/messages...) can result in an invalid thread access. Checks improved returning directly without execution of unnecessary (and erroneous) futher checks. Also added checks for disposed display in SWTUIPlayer class. Tested by execution of multiple RCPTT test suites without previously thrown exception.