### PR TITLE
Pass eclipse.ini VM arguments through unchanged

### DIFF
--- a/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/internal/target/TargetPlatformHelper.java
+++ b/launching/org.eclipse.rcptt.launching.ext/src/org/eclipse/rcptt/launching/internal/target/TargetPlatformHelper.java
@@ -920,7 +920,6 @@ public class TargetPlatformHelper implements ITargetPlatformHelper {
 		}
 
 		removeUnsupportedVMArgs(lines);
-		addUnresolvedVMArgs(lines);
 
 		return lines;
 	}
@@ -928,7 +927,6 @@ public class TargetPlatformHelper implements ITargetPlatformHelper {
 	private static final String VMARG_ADD_MODULES = "--add-modules";
 	private static final String VMARG_PERMIT_ILLEGAL_ACCESS = "--permit-illegal-access";
 	private static final String VMARG_ADD_OPENS = "--add-opens";
-	private static final String VMARG_ALL_UNNAMED = "ALL-UNNAMED";
 
 	private void removeUnsupportedVMArgs(List<String> lines) {
 		String[] javaVersions = getJavaVersions();
@@ -944,17 +942,6 @@ public class TargetPlatformHelper implements ITargetPlatformHelper {
 						|| line.startsWith(VMARG_PERMIT_ILLEGAL_ACCESS)
 						|| line.startsWith(VMARG_ADD_OPENS)) {
 					iterator.remove();
-				}
-			}
-		}
-	}
-
-	private void addUnresolvedVMArgs(List<String> lines) {
-		int startIndex = lines.indexOf(VMARG_ADD_OPENS);
-		if (startIndex != -1) {		
-			for (int i = startIndex; i < lines.size(); i++) {
-				if (lines.get(i).contains(VMARG_ALL_UNNAMED) && !lines.get(i-1).startsWith(VMARG_ADD_OPENS)) {
-					lines.add(i, VMARG_ADD_OPENS);
 				}
 			}
 		}


### PR DESCRIPTION
addUnresolvedVMArgs inserted a bare --add-opens in front of every vmargs line containing the string ALL-UNNAMED. Products now carry --enable-native-access=ALL-UNNAMED for JEP 472, which matched that test, so the AUT was launched with

    --add-opens --enable-native-access=ALL-UNNAMED

and died with "Error: --add-opens requires modules to be specified" before it could write any startup data.

Nothing in RCPTT separates an --add-opens from its operand, so the operands the repair looked for can only come from the ini file itself, and the Eclipse launcher passes every vmargs line to the JVM as an option of its own. An ini that needs the repair therefore cannot start the product outside RCPTT either, and repairing it only hides that.

Assisted-by: Anthropic Claude Code (claude-opus-5[1m])